### PR TITLE
Add option to override result via query parameter

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -6,12 +6,23 @@ interface HomeProps {
 }
 
 export const handler: Handlers<HomeProps> = {
-  GET(_, ctx) {
-    const today = new Date();
-    const start = new Date(today.getFullYear(), 11, 1); // 1 Dec
-    const end = new Date(today.getFullYear(), 11, 25); // 25 Dec
-    const canWearSweater = today >= start && today <= end;
+  GET(req, ctx) {
+    const url = new URL(req.url);
+    const result = url.searchParams.get("result");
 
+    let canWearSweater: boolean;
+    if (result === "yes") {
+      canWearSweater = true;
+    } else if (result === "no") {
+      canWearSweater = false;
+    } else {
+      const today = new Date();
+      const start = new Date(today.getFullYear(), 11, 1); // 1 Dec
+      const end = new Date(today.getFullYear(), 11, 25); // 25 Dec
+      canWearSweater = today >= start && today <= end;
+    }
+
+    const today = new Date();
     const christmas = new Date(today.getFullYear(), 11, 25);
     const diffTime = Math.abs(christmas.getTime() - today.getTime());
     const daysUntilChristmas = Math.ceil(diffTime / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
Fixes #15

Add an option to override the result via a query parameter.

* Modify the `GET` handler in `routes/index.tsx` to check for the `result` query parameter.
* Set `canWearSweater` to `true` if `result` is "yes".
* Set `canWearSweater` to `false` if `result` is "no".
* Use the original date-based logic if `result` is not present.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tristanhollman/kanikeenkersttruiaan/pull/16?shareId=08a294c8-414d-4aad-a071-be5e991e1db3).